### PR TITLE
Add multi-tenant and personal Microsoft account support

### DIFF
--- a/src/CalendarSync.Cli/Commands/AccountAddCommands.cs
+++ b/src/CalendarSync.Cli/Commands/AccountAddCommands.cs
@@ -21,8 +21,8 @@ public static class AccountAddCommands
     private static Command BuildMicrosoftCommand()
     {
         var idOpt = new Option<string>("--id") { Required = true, Description = "Friendly name (e.g. 'work-ms')" };
-        var tenantIdOpt = new Option<string>("--tenant-id") { Required = true, Description = "Entra tenant ID or domain" };
-        var clientIdOpt = new Option<string>("--client-id") { Required = true, Description = "App registration client ID" };
+        var tenantIdOpt = new Option<string?>("--tenant-id") { Description = "Entra tenant ID or domain. Omit for multi-tenant (any organisation) app registrations." };
+        var clientIdOpt = new Option<string?>("--client-id") { Description = "App registration client ID. Omit to use the built-in multi-tenant app." };
         var displayNameOpt = new Option<string?>("--display-name") { Description = "Optional display name" };
         var deviceCodeOpt = new Option<bool>("--device-code")
         {
@@ -55,7 +55,7 @@ public static class AccountAddCommands
                 Provider = CalendarProvider.Microsoft,
                 DisplayName = parseResult.GetValue(displayNameOpt),
                 TenantId = parseResult.GetValue(tenantIdOpt),
-                ClientId = parseResult.GetValue(clientIdOpt),
+                ClientId = parseResult.GetValue(clientIdOpt) ?? "cef0f602-ecd5-49d1-a2f9-f905ce85cc5a",
                 UseDeviceCode = useDeviceCode
             });
 

--- a/src/CalendarSync.Cli/Commands/SetupCommand.cs
+++ b/src/CalendarSync.Cli/Commands/SetupCommand.cs
@@ -152,6 +152,7 @@ public static class SetupCommand
 
         var prompt = new MultiSelectionPrompt<CalendarInfo>()
             .Title("Select calendars to include in planning:")
+            .NotRequired()
             .UseConverter(c => c.Name)
             .AddChoices(calendars);
 

--- a/src/CalendarSync.Cli/Providers/MicrosoftCalendarProvider.cs
+++ b/src/CalendarSync.Cli/Providers/MicrosoftCalendarProvider.cs
@@ -21,31 +21,46 @@ public class MicrosoftCalendarProvider : ICalendarProvider
 
         try
         {
-            await app.AcquireTokenSilent(Scopes, accounts.FirstOrDefault()).ExecuteAsync(ct);
+            var silent = await app.AcquireTokenSilent(Scopes, accounts.FirstOrDefault()).ExecuteAsync(ct);
+            StoreHomeTenantIfNeeded(account, silent);
             return;
         }
         catch (MsalUiRequiredException) { }
 
+        AuthenticationResult result;
         if (account.UseDeviceCode)
         {
-            await AcquireViaDeviceCodeAsync(app, Scopes, ct);
-            return;
+            result = await AcquireViaDeviceCodeAsync(app, Scopes, ct);
+        }
+        else
+        {
+            // Primary: interactive browser / PKCE — no client secret required
+            try
+            {
+                result = await app.AcquireTokenInteractive(Scopes)
+                    .WithUseEmbeddedWebView(false)
+                    .ExecuteAsync(ct);
+            }
+            catch (MsalClientException ex) when (ex.ErrorCode is "authentication_ui_failed" or "browser_not_supported")
+            {
+                Console.WriteLine("[No browser available, falling back to device code flow]");
+                result = await AcquireViaDeviceCodeAsync(app, Scopes, ct);
+            }
         }
 
-        // Primary: interactive browser / PKCE — no client secret required
-        try
-        {
-            await app.AcquireTokenInteractive(Scopes)
-                .WithUseEmbeddedWebView(false)
-                .ExecuteAsync(ct);
-            return;
-        }
-        catch (MsalClientException ex) when (ex.ErrorCode is "authentication_ui_failed" or "browser_not_supported")
-        {
-            Console.WriteLine("[No browser available, falling back to device code flow]");
-        }
+        StoreHomeTenantIfNeeded(account, result);
+    }
 
-        await AcquireViaDeviceCodeAsync(app, Scopes, ct);
+    private static void StoreHomeTenantIfNeeded(AccountConfig account, AuthenticationResult result)
+    {
+        if (account.TenantId is not null) return;
+        var homeTenant = result.Account?.HomeAccountId.TenantId;
+        if (homeTenant is null) return;
+
+        account.TenantId = homeTenant;
+        var config = ConfigManager.Load();
+        var stored = config.Accounts.FirstOrDefault(a => a.Id == account.Id);
+        if (stored is not null) { stored.TenantId = homeTenant; ConfigManager.Save(config); }
     }
 
     public async Task LogoutAsync(AccountConfig account, CancellationToken ct = default)
@@ -151,9 +166,9 @@ public class MicrosoftCalendarProvider : ICalendarProvider
         return new GraphServiceClient(new TokenCredentialAdapter(provider), Scopes);
     }
 
-    private static async Task AcquireViaDeviceCodeAsync(IPublicClientApplication app, string[] scopes, CancellationToken ct)
+    private static async Task<AuthenticationResult> AcquireViaDeviceCodeAsync(IPublicClientApplication app, string[] scopes, CancellationToken ct)
     {
-        await app.AcquireTokenWithDeviceCode(scopes, deviceCodeResult =>
+        return await app.AcquireTokenWithDeviceCode(scopes, deviceCodeResult =>
         {
             Console.WriteLine();
             Console.WriteLine(deviceCodeResult.Message);
@@ -167,21 +182,34 @@ public class MicrosoftCalendarProvider : ICalendarProvider
         if (_apps.TryGetValue(account.Id, out var existing))
             return existing;
 
-        var app = PublicClientApplicationBuilder
+        var builder = PublicClientApplicationBuilder
             .Create(account.ClientId)
-            .WithAuthority(AzureCloudInstance.AzurePublic, account.TenantId)
-            .WithRedirectUri("http://localhost")
-            .Build();
+            .WithRedirectUri("http://localhost");
 
-        RegisterFileCache(app, account.TenantId!);
+        if (account.TenantId is not null)
+            builder = builder.WithAuthority(AzureCloudInstance.AzurePublic, account.TenantId);
+        else
+            builder = builder.WithAuthority(AadAuthorityAudience.AzureAdAndPersonalMicrosoftAccount);
+
+        var app = builder.Build();
+
+        RegisterFileCache(app, account);
         _apps[account.Id] = app;
         return app;
     }
 
-    private static void RegisterFileCache(IPublicClientApplication app, string tenantId)
+    private static void RegisterFileCache(IPublicClientApplication app, AccountConfig account)
     {
         var cacheDir = Config.ConfigManager.TokenCacheDir;
-        var cachePath = Path.Combine(cacheDir, $"msal_{tenantId}.cache");
+        var cachePath = Path.Combine(cacheDir, $"msal_{account.Id}.cache");
+
+        // Migrate from old tenant-based cache name — avoids forcing re-login after upgrade
+        if (!File.Exists(cachePath) && account.TenantId is not null)
+        {
+            var oldPath = Path.Combine(cacheDir, $"msal_{account.TenantId}.cache");
+            if (File.Exists(oldPath))
+                File.Copy(oldPath, cachePath);
+        }
 
         app.UserTokenCache.SetBeforeAccess(args =>
         {


### PR DESCRIPTION
## Summary
- `account add microsoft` no longer requires `--tenant-id` or `--client-id`; omitting `--client-id` falls back to the built-in shared app registration (`cef0f602-ecd5-49d1-a2f9-f905ce85cc5a`)
- Auth uses the `common` endpoint (any Entra tenant + personal MSA) when no tenant ID is configured; resolved home tenant is persisted to config after first login
- Token cache renamed from `msal_{tenantId}.cache` → `msal_{accountId}.cache` with automatic migration to avoid forcing re-login on upgrade
- Setup calendar selection now allows zero calendars to be selected

## Test plan
- [ ] `account add microsoft --id work` (no tenant/client) → signs in via browser/device code, home tenant stored in config
- [ ] `account add microsoft --id work --tenant-id <tid>` → behaves as before (no regression)
- [ ] Personal MSA (@outlook.com) login works
- [ ] Existing accounts with old `msal_{tenantId}.cache` are migrated without re-login
- [ ] `setup` allows proceeding with zero calendars selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)